### PR TITLE
Let the user skip cloning a repo

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ phoenix_app_group: app
 phoenix_app_path: /var/www
 phoenix_app_port: 4000
 phoenix_app_mix_env: prod
-phoenix_app_repository: ""
+phoenix_app_repository: null
 phoenix_app_version: master
 
 phoenix_app_bin: "mix phoenix.server"

--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -10,6 +10,7 @@
     version: "{{ phoenix_app_version }}"
   become: yes
   become_user: "{{ phoenix_app_user }}"
+  when: phoenix_app_repository
   register: phoenix_app_clone
   notify: phoenix_app - restart
 
@@ -21,7 +22,7 @@
     state: latest
   become: yes
   become_user: "{{ phoenix_app_user }}"
-  when: phoenix_app_clone.changed and phoenix_app_run_brunch
+  when: (not phoenix_app_clone or phoenix_app_clone.changed) and phoenix_app_run_brunch
   notify: phoenix_app - restart
 
 - name: phoenix | create config directories
@@ -56,7 +57,7 @@
     chdir: "{{ phoenix_app_path }}/{{ phoenix_app_name }}"
   become: yes
   become_user: "{{ phoenix_app_user }}"
-  when: phoenix_app_clone.changed and phoenix_app_run_brunch
+  when: (not phoenix_app_clone or phoenix_app_clone.changed) and phoenix_app_run_brunch
 
 - name: phoenix | digest assets
   command: mix phoenix.digest

--- a/tasks/validate.yml
+++ b/tasks/validate.yml
@@ -1,9 +1,9 @@
 ---
 
-- name: check if repository is defined
+- name: check if repository is valid
   assert:
     that:
-      - phoenix_app_repository is defined and (phoenix_app_repository | length) > 0
+      - not phoenix_app_repository or (phoenix_app_repository | length) > 0
 
 
 - name: check config syntax is valid


### PR DESCRIPTION
It can be useful to fetch the files beforehand, possibly using something else than Git.

This changes the behaviour so that when `phoenix_app_repository` is falsey, cloning is skipped.
