### PR TITLE
[WIP] Include full application environment when running Ecto migrations

### DIFF
--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -71,8 +71,7 @@
 
 - name: mix | migrate
   command: mix ecto.migrate
-  environment:
-    MIX_ENV: "{{ phoenix_app_mix_env }}"
+  environment: {{ phoenix_app_env }}
   args:
     chdir: "{{ phoenix_app_path }}/{{ phoenix_app_name }}"
   become: yes


### PR DESCRIPTION
The database credentials in application config are quite likely to be interpolated from environment variables.

Unfortunately, this change has two problems:
1. It doesn't appear to work at all.
2. It does not merge the `MIX_ENV` variable.

I don't know Ansible or its YAML templating well enough to know what I should really be doing; I wonder if you have any suggestions here, @jacoelho, or if you think switching to the `shell` resource and sourcing `/etc/default/{{ phoenix_app_name }}` similarly to the Upstart script would be a better solution, which I probably can do.
